### PR TITLE
Added @Nullable annotation

### DIFF
--- a/library/src/main/java/io/appflate/droidmvp/SimpleDroidMVPPresenter.java
+++ b/library/src/main/java/io/appflate/droidmvp/SimpleDroidMVPPresenter.java
@@ -16,6 +16,8 @@
 
 package io.appflate.droidmvp;
 
+import android.support.annotation.Nullable;
+
 /**
  * Base class that implements the DroidMVPPresenter interface and provides a base implementation
  * for
@@ -49,7 +51,7 @@ public abstract class SimpleDroidMVPPresenter<V extends DroidMVPView, M>
         return presentationModel;
     }
 
-    protected V getMvpView() {
+    @Nullable protected V getMvpView() {
         return mvpView;
     }
 }


### PR DESCRIPTION
Presenter may mistakenly attempt to access a view after it has been detached. The @Nullable annotation will help the developer prevent this.
